### PR TITLE
Supprime les lignes SVN $Id$ qui figurent dans les entêtes.

### DIFF
--- a/assets/register.php
+++ b/assets/register.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Biblio;
 

--- a/class/Database.php
+++ b/class/Database.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio;
 

--- a/class/DatabaseIndexer.php
+++ b/class/DatabaseIndexer.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio;
 

--- a/class/Field/Author.php
+++ b/class/Field/Author.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Authors.php
+++ b/class/Field/Authors.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Collection.php
+++ b/class/Field/Collection.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Collections.php
+++ b/class/Field/Collections.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Content.php
+++ b/class/Field/Content.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Contents.php
+++ b/class/Field/Contents.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/CreatedBy.php
+++ b/class/Field/CreatedBy.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Creation.php
+++ b/class/Field/Creation.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Date.php
+++ b/class/Field/Date.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Dates.php
+++ b/class/Field/Dates.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Edition.php
+++ b/class/Field/Edition.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Editions.php
+++ b/class/Field/Editions.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Editor.php
+++ b/class/Field/Editor.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Editors.php
+++ b/class/Field/Editors.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Error.php
+++ b/class/Field/Error.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Errors.php
+++ b/class/Field/Errors.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Event.php
+++ b/class/Field/Event.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Extent.php
+++ b/class/Field/Extent.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Extents.php
+++ b/class/Field/Extents.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Format.php
+++ b/class/Field/Format.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Formats.php
+++ b/class/Field/Formats.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Genre.php
+++ b/class/Field/Genre.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Genres.php
+++ b/class/Field/Genres.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Imported.php
+++ b/class/Field/Imported.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Journal.php
+++ b/class/Field/Journal.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Language.php
+++ b/class/Field/Language.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Languages.php
+++ b/class/Field/Languages.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/LastUpdate.php
+++ b/class/Field/LastUpdate.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Link.php
+++ b/class/Field/Link.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Links.php
+++ b/class/Field/Links.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Media.php
+++ b/class/Field/Media.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Medias.php
+++ b/class/Field/Medias.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Number.php
+++ b/class/Field/Number.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Numbers.php
+++ b/class/Field/Numbers.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Organisation.php
+++ b/class/Field/Organisation.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Organisations.php
+++ b/class/Field/Organisations.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/OtherTitle.php
+++ b/class/Field/OtherTitle.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/OtherTitles.php
+++ b/class/Field/OtherTitles.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Owner.php
+++ b/class/Field/Owner.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Owners.php
+++ b/class/Field/Owners.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/PostType.php
+++ b/class/Field/PostType.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Ref.php
+++ b/class/Field/Ref.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Relation.php
+++ b/class/Field/Relation.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Relations.php
+++ b/class/Field/Relations.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Status.php
+++ b/class/Field/Status.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Title.php
+++ b/class/Field/Title.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Topic.php
+++ b/class/Field/Topic.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Topics.php
+++ b/class/Field/Topics.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Translation.php
+++ b/class/Field/Translation.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Translations.php
+++ b/class/Field/Translations.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Field/Type.php
+++ b/class/Field/Type.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Field;
 

--- a/class/Import/BdspCsv.php
+++ b/class/Import/BdspCsv.php
@@ -3,7 +3,6 @@
 * @package     Prisme
 * @subpackage  modules
 * @author      Daniel Ménard <daniel.menard.35@gmail.com>
-* @version     SVN: $Id$
 */
 namespace Docalist\Biblio\Import;
 

--- a/class/Installer.php
+++ b/class/Installer.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio;
 

--- a/class/Pages/AdminDatabases.php
+++ b/class/Pages/AdminDatabases.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Pages;
 

--- a/class/Pages/EditReference.php
+++ b/class/Pages/EditReference.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Pages;
 

--- a/class/Pages/ImportPage.php
+++ b/class/Pages/ImportPage.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Pages;
 

--- a/class/Pages/ListReferences.php
+++ b/class/Pages/ListReferences.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Pages;
 

--- a/class/Plugin.php
+++ b/class/Plugin.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio;
 

--- a/class/Reference.php
+++ b/class/Reference.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio;
 

--- a/class/Reference/Article.php
+++ b/class/Reference/Article.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Reference;
 

--- a/class/Reference/Book.php
+++ b/class/Reference/Book.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Reference;
 

--- a/class/Reference/BookChapter.php
+++ b/class/Reference/BookChapter.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Reference;
 

--- a/class/Reference/Degree.php
+++ b/class/Reference/Degree.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Reference;
 

--- a/class/Reference/Film.php
+++ b/class/Reference/Film.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Reference;
 

--- a/class/Reference/Legislation.php
+++ b/class/Reference/Legislation.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Reference;
 

--- a/class/Reference/Meeting.php
+++ b/class/Reference/Meeting.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Reference;
 

--- a/class/Reference/Periodical.php
+++ b/class/Reference/Periodical.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Reference;
 

--- a/class/Reference/PeriodicalIssue.php
+++ b/class/Reference/PeriodicalIssue.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Reference;
 

--- a/class/Reference/ReferenceIterator.php
+++ b/class/Reference/ReferenceIterator.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Reference;
 

--- a/class/Reference/Report.php
+++ b/class/Reference/Report.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Reference;
 

--- a/class/Reference/WebSite.php
+++ b/class/Reference/WebSite.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Reference;
 

--- a/class/Settings/DatabaseSettings.php
+++ b/class/Settings/DatabaseSettings.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Settings;
 

--- a/class/Settings/Settings.php
+++ b/class/Settings/Settings.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Settings;
 

--- a/class/Settings/TypeSettings.php
+++ b/class/Settings/TypeSettings.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Settings;
 

--- a/class/Type/BiblioField.php
+++ b/class/Type/BiblioField.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Type;
 

--- a/class/Type/BiblioFieldTrait.php
+++ b/class/Type/BiblioFieldTrait.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Type;
 

--- a/class/Type/DateTime.php
+++ b/class/Type/DateTime.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Type;
 

--- a/class/Type/Group.php
+++ b/class/Type/Group.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Core
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 namespace Docalist\Biblio\Type;
 

--- a/class/Type/Integer.php
+++ b/class/Type/Integer.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Type;
 

--- a/class/Type/MultiField.php
+++ b/class/Type/MultiField.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Type;
 

--- a/class/Type/Object.php
+++ b/class/Type/Object.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Type;
 

--- a/class/Type/Repeatable.php
+++ b/class/Type/Repeatable.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Type;
 

--- a/class/Type/String.php
+++ b/class/Type/String.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Type;
 

--- a/class/Type/StringTable.php
+++ b/class/Type/StringTable.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Type;
 

--- a/docalist-biblio.php
+++ b/docalist-biblio.php
@@ -19,7 +19,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 namespace Docalist\Biblio;

--- a/scripts/marc21-authorities/lc-autorithy.php
+++ b/scripts/marc21-authorities/lc-autorithy.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 
 /*

--- a/scripts/marc21-authorities/table-header.txt
+++ b/scripts/marc21-authorities/table-header.txt
@@ -9,7 +9,6 @@
 # @package     Docalist
 # @subpackage  Tables
 # @author      Daniel Ménard <daniel.menard@laposte.net>
-# @version     SVN: $Id$
 # ------------------------------------------------------------------------------
 #
 # ------------------------------------------------------------------------------

--- a/scripts/marc21-relators-fr/scrap.php
+++ b/scripts/marc21-relators-fr/scrap.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 
 /*

--- a/scripts/marc21-relators-fr/table-header.txt
+++ b/scripts/marc21-relators-fr/table-header.txt
@@ -9,7 +9,6 @@
 # @package     Docalist
 # @subpackage  Tables
 # @author      Daniel Ménard <daniel.menard@laposte.net>
-# @version     SVN: $Id$
 # ------------------------------------------------------------------------------
 #
 # ------------------------------------------------------------------------------

--- a/tables/relators/marc21-relators_en.txt
+++ b/tables/relators/marc21-relators_en.txt
@@ -9,7 +9,6 @@
 # @package     Docalist
 # @subpackage  Tables
 # @author      Daniel Ménard <daniel.menard@laposte.net>
-# @version     SVN: $Id$
 # ------------------------------------------------------------------------------
 #
 # ------------------------------------------------------------------------------

--- a/tables/relators/marc21-relators_fr.txt
+++ b/tables/relators/marc21-relators_fr.txt
@@ -9,7 +9,6 @@
 # @package     Docalist
 # @subpackage  Tables
 # @author      Daniel Ménard <daniel.menard@laposte.net>
-# @version     SVN: $Id$
 # ------------------------------------------------------------------------------
 #
 # ------------------------------------------------------------------------------

--- a/tables/relators/relators_unimarc-to-marc21.txt
+++ b/tables/relators/relators_unimarc-to-marc21.txt
@@ -9,7 +9,6 @@
 # @package     Docalist
 # @subpackage  Biblio
 # @author      Daniel Ménard <daniel.menard@laposte.net>
-# @version     SVN: $Id$
 # ------------------------------------------------------------------------------
 #
 # ------------------------------------------------------------------------------

--- a/tables/thesaurus-example.txt
+++ b/tables/thesaurus-example.txt
@@ -9,7 +9,6 @@
 # @package     Docalist
 # @subpackage  Tables
 # @author      Daniel Ménard <daniel.menard@laposte.net>
-# @version     SVN: $Id$
 # ------------------------------------------------------------------------------
 #
 # ------------------------------------------------------------------------------

--- a/tables/topics.php
+++ b/tables/topics.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     SVN: $Id$
  */
 
 /*

--- a/views/database/edit.php
+++ b/views/database/edit.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/database/export-settings.php
+++ b/views/database/export-settings.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/database/import-settings-confirm.php
+++ b/views/database/import-settings-confirm.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/database/import-settings.php
+++ b/views/database/import-settings.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/database/list.php
+++ b/views/database/list.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/delete-all/confirm.php
+++ b/views/delete-all/confirm.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/delete-all/delete-all.php
+++ b/views/delete-all/delete-all.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/export/choose-exporter.php
+++ b/views/export/choose-exporter.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/export/choose-refs.php
+++ b/views/export/choose-refs.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/grid/edit.js
+++ b/views/grid/edit.js
@@ -9,7 +9,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 /*
  * Gère la liste des champs pour un type de notice.

--- a/views/grid/edit.php
+++ b/views/grid/edit.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/grid/list.php
+++ b/views/grid/list.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/grid/settings.php
+++ b/views/grid/settings.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/grid/tophp.php
+++ b/views/grid/tophp.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/import/choose.js
+++ b/views/import/choose.js
@@ -9,7 +9,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 
 /**

--- a/views/import/choose.php
+++ b/views/import/choose.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/import/import.php
+++ b/views/import/import.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/reference/choose-type.php
+++ b/views/reference/choose-type.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/type/add.php
+++ b/views/type/add.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/type/display.php
+++ b/views/type/display.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/type/edit.php
+++ b/views/type/edit.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 

--- a/views/type/list.php
+++ b/views/type/list.php
@@ -10,7 +10,6 @@
  * @package     Docalist
  * @subpackage  Biblio
  * @author      Daniel Ménard <daniel.menard@laposte.net>
- * @version     $Id$
  */
 namespace Docalist\Biblio\Views;
 


### PR DESCRIPTION
$Id$ est l'un des mots-clés auto reconnus par SVN. Cela permettait
d'avoir, directement dans le code source, le numéro de révision du
fichier.

Comme il n'y a pas d'équivalent dans git, suppression de cette ligne
dans tous les fichiers.