### PR TITLE
Compatibilité WP 4.3

### DIFF
--- a/class/Pages/EditReference.php
+++ b/class/Pages/EditReference.php
@@ -38,6 +38,11 @@ class EditReference {
     const NONCE = 'dcl_nonce';
 
     /**
+     * Le nom du champ parent de tous les champs de la notice.
+     */
+    const FORM_NAME = 'dbref';
+
+    /**
      * La base de données documentaire.
      *
      * @var Database
@@ -272,6 +277,10 @@ class EditReference {
             // binde le formulaire
             $form->bind($ref);
 
+            // Regroupe tous les champs dans un champ parent 'dbref'
+            // Cela évite que wp interfére avec nos champs (#250, #335 par exemple)
+            $form->name(self::FORM_NAME);
+
             // Envoie les assets requis
             $assets->add($form->assets());
 
@@ -351,14 +360,21 @@ class EditReference {
         if ($debug) {
             header('content-type: text/html; charset=UTF8');
             echo '<style>code{color: darkblue;font-weight: bold;}</style>';
+            echo '<h1>Données de $postarr</h1>';
+            var_dump($postarr);
             echo '<h1>Données de $data</h1>';
             var_dump($data);
+        }
+
+        // Tous les champs sont dans un champ parent 'dbref' (cf. edit)
+        if (! isset($postarr[self::FORM_NAME])) {
+            die('Aucune donnée transmise dans '. self::FORM_NAME . '[]');
         }
 
         // Wordpress considère que "content" est un alias de "post_content"
         // Du coup, on récupère dans $data.post_content le champ docalist
         // "content" (un tableau donc comme le champ est un objet multivalué)
-        $data['post_content'] = '';
+        // $data['post_content'] = ''; Inutile maintenant qu'on le champ parent dbref
 
         /*
          * Etape 1
@@ -393,7 +409,7 @@ class EditReference {
          * Met à jour la référence avec les données des metaboxes.
          */
         foreach($this->metaboxes($ref) as $metabox) {
-            $metabox->bind($postarr);
+            $metabox->bind($postarr[self::FORM_NAME]);
             foreach($metabox->data() as $key => $value) {
                 $ref->$key = $value;
             }

--- a/class/Pages/ListReferences.php
+++ b/class/Pages/ListReferences.php
@@ -366,7 +366,7 @@ class ListReferences{
      * - label : le libellé du type (par exemple "Article de périodique").
      */
     protected function countTypes() {
-        static $cache;
+        static $cache = null;
 
         global $wpdb;
 
@@ -423,7 +423,7 @@ class ListReferences{
      * - count : le nombre de notices créé pour cette année,
      */
     protected function countYears() {
-        static $cache;
+        static $cache = null;
 
         global $wpdb;
 

--- a/class/Pages/ListReferences.php
+++ b/class/Pages/ListReferences.php
@@ -61,25 +61,33 @@ class ListReferences{
     protected function setupColumns() {
         // Définit la liste des colonnes à afficher
         add_filter("manage_{$this->postType}_posts_columns", function($columns) {
-            echo
-                '<style type="text/css">
-                    .widefat .column-ref  { width: 3em; text-align: right }
-                    .column-type { width: 5em }
-                    .column-creation { width: 9em }
-                    .column-lastupdate { width: 9em }
-                </style>';
+            static $customColumns = null;
 
-            return [
-                'cb' => $columns['cb'],
-                'ref' => __('Ref', 'docalist-biblio'),
-                'type' => __('Type', 'docalist-biblio'),
-                'title' => $columns['title'],
-                'creation' => __('Création', 'docalist-biblio'),
-                'lastupdate' => __('Mise à jour', 'docalist-biblio'),
-//                 'author' => $columns['author'],
-                'comments' => $columns['comments'],
-//                 'date' => $columns['date'],
-            ];
+            // On peut être appellé plusieurs fois, init au 1er appel
+            if (is_null($customColumns)) {
+                echo
+                    '<style type="text/css">
+                        .widefat .column-ref  { width: 3em; text-align: right }
+                        .column-type { width: 5em }
+                        .column-creation { width: 9em }
+                        .column-lastupdate { width: 9em }
+                    </style>';
+
+                $customColumns = [
+                    'cb' => $columns['cb'],
+                    'ref' => __('Ref', 'docalist-biblio'),
+                    'type' => __('Type', 'docalist-biblio'),
+                    'title' => $columns['title'],
+                    'creation' => __('Création', 'docalist-biblio'),
+                    'lastupdate' => __('Mise à jour', 'docalist-biblio'),
+    //                 'author' => $columns['author'],
+                    'comments' => $columns['comments'],
+    //                 'date' => $columns['date'],
+                ];
+            }
+
+            // Ok
+            return $customColumns;
         });
 
         // Fournit le contenu des colonnes personnalisées pour chaque notice

--- a/class/Pages/ListReferences.php
+++ b/class/Pages/ListReferences.php
@@ -75,9 +75,9 @@ class ListReferences{
 
                 $customColumns = [
                     'cb' => $columns['cb'],
-                    'ref' => __('Ref', 'docalist-biblio'),
-                    'type' => __('Type', 'docalist-biblio'),
                     'title' => $columns['title'],
+                    'type' => __('Type', 'docalist-biblio'),
+                    'ref' => __('Ref', 'docalist-biblio'),
                     'creation' => __('Création', 'docalist-biblio'),
                     'lastupdate' => __('Mise à jour', 'docalist-biblio'),
     //                 'author' => $columns['author'],

--- a/class/Pages/ListReferences.php
+++ b/class/Pages/ListReferences.php
@@ -81,9 +81,13 @@ class ListReferences{
                     'creation' => __('Création', 'docalist-biblio'),
                     'lastupdate' => __('Mise à jour', 'docalist-biblio'),
     //                 'author' => $columns['author'],
-                    'comments' => $columns['comments'],
     //                 'date' => $columns['date'],
                 ];
+
+                // La colonne 'comments' n'existe que si les commentaires sont actifs
+                if (post_type_supports($this->postType, 'comments')) {
+                    $customColumns['comments'] = $columns['comments'];
+                }
             }
 
             // Ok


### PR DESCRIPTION
- Amélioration de ListReferences (évite de générer plusieurs fois la css)
- Suppression de warnings apparus avec WP 4.3 (docalist/docalist#250 et docalist/docalist#335)
- BO responsive (https://github.com/docalist/docalist/issues/313)